### PR TITLE
Elide default parameter settings, add benchmarks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
     <groupId>org.janelia</groupId>
     <artifactId>n5-zstandard</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>N5 Zstandard</name>
 	<description>Zstandard compression for N5</description>
 	<url>https://github.com/JaneliaSciComp/n5-zstandard</url>


### PR DESCRIPTION
I added some benchmarking tests and then reduce the number of native synchronized calls.

For 100 chunks of 16 MB of `(short) (rand.nextGaussian() * Short.MAX_VALUE/2048.0 + 255)`, I get the following results.

The test parameter pairs are `{compression_level, number_of_threads}`. Timings are for the entire `AbstractN5Test` suite. The traditional tests take about a second to run in total. The rest of the time is spent compressing the 100 chunks .

```java
    	int m = Zstd.minCompressionLevel();
    	int M = Zstd.maxCompressionLevel();
    	System.out.println("Minimum compression level: " + m);
    	System.out.println("Maximum compression level: " + M);
    	//Comments below are with 16 MiB of int16 255 +/- 32;
		return Arrays.asList(new Object[][] {
			{ m,0}, { m,2}, { m,4}, { m,8}, // test  0 -  3, 100%,  3.5s, 1 thread
			{-2,0}, {-2,2}, {-2,4}, {-2,8}, // test  4 -  7,  97%,  4.5s, 1 thread
			{-1,0}, {-1,2}, {-1,4}, {-1,8}, // test  8 - 11,  96%,  5.0s, 8 threads
			//Compression level 0 means default (3)
			{ 1,0}, { 1,2}, { 1,4}, { 1,8}, // test 12 - 15,  55%,  5.5s, 8 threads
			{ 2,0}, { 2,2}, { 2,4}, { 2,8}, // test 16 - 19,  53%,  8.1s, 4 threads
			{ 3,0}, { 3,2}, { 3,4}, { 3,8}, // test 20 - 23,  51%, 14.0s, 4 threads
			{ 6,0}, { 6,2}, { 6,4}, { 6,8}, // test 24 - 27,  49%, 25.5s, 2 threads
			//{12,0}, {12,1}, {12,2}, {12,4}, // test 28 - 31
			//{15,0}, {15,1}, {15,2}, {15,4}, // test 32 - 35
			//{ M,8}, { M,1}, { M,2}, { M,4}  // test 36 - 39
		});
```

The effect of eliding unncessary native synchronized calls saved at most 100 ms.