### PR TITLE
Retain License at a single file at the root of the project

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,6 @@
-Copyright (c) 2023 - 2025, Howard Hughes Medical Institute
+## BSD 3-Clause License
+
+Copyright (c) 2023-2026, Howard Hughes Medical Institute
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,9 @@
 		<license.projectName>n5-zstandard</license.projectName>
 		<license.organizationName>HHMI</license.organizationName>
 		<license.copyrightOwners>Howard Hughes Medical Institute</license.copyrightOwners>
+		<!-- managed by `copy-resources` plugin  -->
+		<license.skipUpdateLicense>true</license.skipUpdateLicense>
+		<license.skipUpdateProjectLicense>true</license.skipUpdateProjectLicense>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
@@ -119,5 +122,53 @@
 		  <scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>build-helper-maven-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>timestamp-property</id>
+							<goals>
+								<goal>timestamp-property</goal>
+							</goals>
+							<phase>validate</phase>
+							<configuration>
+								<name>current.year</name>
+								<pattern>yyyy</pattern>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<artifactId>maven-resources-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>copy</id>
+							<phase>compile</phase>
+							<goals>
+								<goal>copy-resources</goal>
+							</goals>
+							<configuration>
+								<outputDirectory>${basedir}</outputDirectory>
+								<resources>
+									<resource>
+										<directory>doc</directory>
+										<includes>
+											<include>*.md</include>
+										</includes>
+										<filtering>true</filtering>
+									</resource>
+								</resources>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 
 </project>

--- a/src/main/java/org/janelia/scicomp/n5/zstandard/ZstandardCompression.java
+++ b/src/main/java/org/janelia/scicomp/n5/zstandard/ZstandardCompression.java
@@ -1,35 +1,3 @@
-/*-
- * #%L
- * n5-zstandard
- * %%
- * Copyright (C) 2023 - 2025 Howard Hughes Medical Institute
- * %%
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- * 
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * 3. Neither the name of the HHMI nor the names of its contributors
- *    may be used to endorse or promote products derived from this software without
- *    specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.scicomp.n5.zstandard;
 
 import com.github.luben.zstd.BufferPool;

--- a/src/test/java/org/janelia/scicomp/n5/zstandard/ZstandardCompressionTest.java
+++ b/src/test/java/org/janelia/scicomp/n5/zstandard/ZstandardCompressionTest.java
@@ -1,35 +1,3 @@
-/*-
- * #%L
- * n5-zstandard
- * %%
- * Copyright (C) 2023 - 2025 Howard Hughes Medical Institute
- * %%
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- * 
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * 3. Neither the name of the HHMI nor the names of its contributors
- *    may be used to endorse or promote products derived from this software without
- *    specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.scicomp.n5.zstandard;
 
 import static org.junit.Assert.assertArrayEquals;


### PR DESCRIPTION
See https://github.com/saalfeldlab/n5/issues/188 for motivation:

- Removes redundant license headers from source files
- Disable the auto-adding of license headers to source files
- Retain project license in a single `LICENSE.md` file at the root based on `doc/LICENSE.md` template
- specify `license.skipUpdateProjectLicense = true` in `pom.xml
  - Avoids errantly generating a duplicate `LICENSE.txt`
  - used by `scijava-script/release-version.sh` script to disable license updates without requiring `--skip-license-update` 